### PR TITLE
WIP: Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:buster-slim
+
+RUN apt update && \
+    apt install -y lsb-release vim bash sudo perl-modules build-essential git liblwp-protocol-https-perl && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN cpan CPAN
+ 
+COPY ./ /opt/memento
+
+RUN cd /opt/memento && ./install.pl
+
+RUN groupadd --gid 1000 memento && \
+    useradd \
+      --uid 1000 \
+      --gid 1000 \
+      --groups sudo \
+      --create-home \
+      --shell /bin/bash \
+      memento
+
+RUN echo "memento\nmemento" | passwd memento
+
+USER memento
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,12 @@ COPY ./ /opt/memento
 
 RUN cd /opt/memento && ./install.pl
 
+RUN mkdir -p /opt/memento/Memento/Tool/custom && \ 
+    cd /opt/memento/Memento/Tool/custom && \
+    git clone https://github.com/bmeme/memento-plugins.git && \
+    git clone https://github.com/bmeme/memento-docker.git && \
+    git clone https://github.com/bmeme/memento-kickstarter.git
+
 RUN groupadd --gid 1000 memento && \
     useradd \
       --uid 1000 \

--- a/README.docker.md
+++ b/README.docker.md
@@ -1,0 +1,27 @@
+
+# Build the docker image
+
+You can build the memento docker image by running the following command:
+
+```
+$ docker build . -t memento
+```
+
+Please note: the `Dockerfile` assumes that your user and group id is 1000.
+Please edit the file accordingly to your system settings.
+
+# Run memento using docker
+
+With the built image presents on your system, you can use `./cmemento` wrapper to run memento.
+Note: it will read (and write) the configuration from `~/.memento` directory. 
+
+If you want to use cmemento from anywhere, just copy the script in a system path:
+
+```
+$ sudo cp cmemento /usr/local/bin
+```
+
+Example:
+```
+$ cmemento jira projects
+```

--- a/cmemento
+++ b/cmemento
@@ -24,5 +24,11 @@ else
 	WORKDIR="/usr/src/app"
 fi
 
-docker run -v /home/$(whoami)/.memento:/home/memento/.memento -v ${SOURCE}:${DEST} -w ${WORKDIR} -it memento /bin/bash -c "memento ${CMD}"
+docker run \
+	-v /home/$(whoami)/.memento:/home/memento/.memento \
+	-v ${SOURCE}:${DEST} \
+	-v ~/.ssh:/home/memento/.ssh \
+	-v $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) \
+	-e SSH_AUTH_SOCK=$SSH_AUTH_SOCK \
+	-w ${WORKDIR} -it memento /bin/bash -c "memento ${CMD}"
 

--- a/cmemento
+++ b/cmemento
@@ -24,7 +24,7 @@ else
 	WORKDIR="/usr/src/app"
 fi
 
-docker run \
+docker run --rm \
 	-v /home/$(whoami)/.memento:/home/memento/.memento \
 	-v ${SOURCE}:${DEST} \
 	-v ~/.ssh:/home/memento/.ssh \

--- a/cmemento
+++ b/cmemento
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+QUOTEDCMD=()
+for token in "$@"; do
+  QUOTEDCMD+=($(printf "%q" "$token"))
+done
+CMD="${QUOTEDCMD[*]}"
+if [[ -z "$CMD" ]]
+then
+  CMD="bash"
+fi
+
+docker run -v /home/$(whoami)/.memento:/home/memento/.memento -v $(pwd):/usr/src/app -w /usr/src/app -it memento /bin/bash -c "memento ${CMD}"

--- a/cmemento
+++ b/cmemento
@@ -11,4 +11,18 @@ then
   CMD="bash"
 fi
 
-docker run -v /home/$(whoami)/.memento:/home/memento/.memento -v $(pwd):/usr/src/app -w /usr/src/app -it memento /bin/bash -c "memento ${CMD}"
+PWD=$(pwd -P)
+
+if [ -f .git ]; then
+	SOURCE="${PWD}/.."
+	DEST="/usr/src/app"
+	CURRDIR=$(basename ${PWD})
+	WORKDIR="${DEST}/${CURRDIR}"
+else
+	SOURCE="${PWD}"
+	DEST="/usr/src/app"
+	WORKDIR="/usr/src/app"
+fi
+
+docker run -v /home/$(whoami)/.memento:/home/memento/.memento -v ${SOURCE}:${DEST} -w ${WORKDIR} -it memento /bin/bash -c "memento ${CMD}"
+


### PR DESCRIPTION
This is a first implementation of docker support, as described in #7 

Implemented features are:
- add Dockerfile to build memento docker image
- add cmemento wrapper to run the software inside a docker container
- add README for docker support

Actually it has been testing only on a debian based system.
It needs further tests, especially on macOs systems.

@g0blin79 I'm sure you will be happy to test it =)